### PR TITLE
[DAV-3597] Fix redirect authentication mode in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [DAV-2698] Add SDK package and built-in authentication
 - [DAV-2359] Add wallet context support
+- [DAV-3597] Fix authentication issue in Safari
 
 ### v1.4.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2139,9 +2139,9 @@
       }
     },
     "node_modules/@cere/torus-embed": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.1.3.tgz",
-      "integrity": "sha512-Hn23rpgKqe+EGatqse8BY4LFCR+kc/pIsfqK7tjfI3moXWFbtrGNDuJlXOaaX+l0AnLl5LJNuHowq4mbBNX5WA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.1.4.tgz",
+      "integrity": "sha512-Ztvu3Y8gPV4kEm1OqvCBuDVE93M0ur4EcpsgSY6/706DRZYzN4rq9c3oJru8JftP7TZAMNoqjh4wrSYwkzwGFQ==",
       "dependencies": {
         "@metamask/obs-store": "^7.0.0",
         "@toruslabs/http-helpers": "^3.2.0",
@@ -23074,7 +23074,7 @@
       "name": "@cere/embed-wallet",
       "version": "0.0.10",
       "dependencies": {
-        "@cere/torus-embed": "0.1.3",
+        "@cere/torus-embed": "0.1.4",
         "@toruslabs/openlogin-jrpc": "^2.6.0",
         "@types/readable-stream": "^2.3.14"
       }
@@ -24601,7 +24601,7 @@
     "@cere/embed-wallet": {
       "version": "file:packages/embed-wallet",
       "requires": {
-        "@cere/torus-embed": "0.1.3",
+        "@cere/torus-embed": "0.1.4",
         "@toruslabs/openlogin-jrpc": "^2.6.0",
         "@types/readable-stream": "^2.3.14"
       }
@@ -24617,9 +24617,9 @@
       }
     },
     "@cere/torus-embed": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.1.3.tgz",
-      "integrity": "sha512-Hn23rpgKqe+EGatqse8BY4LFCR+kc/pIsfqK7tjfI3moXWFbtrGNDuJlXOaaX+l0AnLl5LJNuHowq4mbBNX5WA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.1.4.tgz",
+      "integrity": "sha512-Ztvu3Y8gPV4kEm1OqvCBuDVE93M0ur4EcpsgSY6/706DRZYzN4rq9c3oJru8JftP7TZAMNoqjh4wrSYwkzwGFQ==",
       "requires": {
         "@metamask/obs-store": "^7.0.0",
         "@toruslabs/http-helpers": "^3.2.0",

--- a/packages/communication/src/wallet/channels.ts
+++ b/packages/communication/src/wallet/channels.ts
@@ -28,6 +28,7 @@ export type LoginData = {
 export type InitChannelIn = {
   name: 'init_stream';
   data: {
+    sessionId?: string;
     context: Context;
     torusWidgetVisibility: boolean;
     network: NetworkInterface;

--- a/packages/communication/src/wallet/createWalletConnection.ts
+++ b/packages/communication/src/wallet/createWalletConnection.ts
@@ -36,7 +36,7 @@ export type WalletConnectionOptions = {
   onInit: (data: InitData) => Promise<boolean>;
   onLogin: (data: LoginChannelIn['data']) => Promise<string>;
   onLoginWithPrivateKey: (data: PrivateKeyLoginChannelIn['data']) => Promise<boolean>;
-  onRehydrate: () => Promise<boolean>;
+  onRehydrate: (params: Pick<InitData, 'sessionId'>) => Promise<boolean>;
   onLogout: () => Promise<boolean>;
   onUserInfoRequest: () => Promise<UserInfo | undefined>;
   onWindowOpen: (data: WindowOptions) => Promise<void>;
@@ -79,7 +79,7 @@ export const createWalletConnection = ({
       chainConfig: getChainConfig(network),
     });
 
-    const rehydrated = await onRehydrate();
+    const rehydrated = await onRehydrate({ sessionId: data.sessionId });
     const userInfo = rehydrated && (await onUserInfoRequest());
 
     if (userInfo) {

--- a/packages/embed-wallet/package.json
+++ b/packages/embed-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere/embed-wallet",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "types": "./src",
   "main": "./dist/cjs",
   "exports": {
@@ -8,7 +8,7 @@
     "require": "./dist/cjs"
   },
   "dependencies": {
-    "@cere/torus-embed": "0.1.3",
+    "@cere/torus-embed": "0.1.4",
     "@toruslabs/openlogin-jrpc": "^2.6.0",
     "@types/readable-stream": "^2.3.14"
   },

--- a/packages/embed-wallet/src/EmbedWallet.ts
+++ b/packages/embed-wallet/src/EmbedWallet.ts
@@ -3,6 +3,7 @@ import { Substream } from '@toruslabs/openlogin-jrpc';
 import Torus, { TORUS_BUILD_ENV_TYPE } from '@cere/torus-embed';
 
 import { createContext } from './createContext';
+import { getAuthRedirectResult } from './getAuthRedirectResult';
 import {
   WalletStatus,
   WalletEvent,
@@ -68,9 +69,11 @@ export class EmbedWallet {
 
   async init({ network, context, env = 'prod' }: WalletInitOptions) {
     this.defaultContext = createContext(context);
+    const { sessionId } = getAuthRedirectResult();
 
     await this.torus.init({
       network,
+      sessionId,
       context: this.defaultContext,
       buildEnv: buildEnvMap[env],
       enableLogging: env !== 'prod',

--- a/packages/embed-wallet/src/getAuthRedirectResult.ts
+++ b/packages/embed-wallet/src/getAuthRedirectResult.ts
@@ -1,0 +1,17 @@
+export const getAuthRedirectResult = () => {
+  const currentUrl = new URL(window.location.href);
+  const queryParams = new URLSearchParams(window.location.hash.slice(1));
+  const sessionId = queryParams.get('sessionId') || undefined;
+
+  if (sessionId) {
+    queryParams.delete('sessionId');
+    currentUrl.hash = queryParams.toString();
+
+    /**
+     * Clean auth specific parameters from the current URL
+     */
+    window.history.replaceState(null, document.title, currentUrl.toString());
+  }
+
+  return { sessionId };
+};

--- a/src/routes/Authorize/AuthorizeRedirect.tsx
+++ b/src/routes/Authorize/AuthorizeRedirect.tsx
@@ -4,6 +4,16 @@ import { useMemo } from 'react';
 
 import { OpenLoginStore } from '~/stores/OpenLoginStore';
 
+const createRedirectUrl = (url: string, sessionId: string) => {
+  const finalUrl = new URL(url);
+  const hashParams = new URLSearchParams(finalUrl.hash.slice(1));
+
+  hashParams.append('sessionId', sessionId);
+  finalUrl.hash = hashParams.toString();
+
+  return finalUrl.toString();
+};
+
 const AuthorizeRedirect = () => {
   const hashParams = new URLSearchParams(window.location.hash.slice(1));
   const queryParams = new URLSearchParams(window.location.search);
@@ -18,8 +28,8 @@ const AuthorizeRedirect = () => {
     store.syncWithEncodedState(result, sessionId);
   }
 
-  if (redirectUrl) {
-    window.location.replace(redirectUrl);
+  if (redirectUrl && sessionId) {
+    window.location.replace(createRedirectUrl(redirectUrl, sessionId));
   }
 
   return (

--- a/src/stores/AuthenticationStore/AuthenticationStore.ts
+++ b/src/stores/AuthenticationStore/AuthenticationStore.ts
@@ -3,7 +3,7 @@ import { makeAutoObservable, reaction, when } from 'mobx';
 import { PopupManagerStore } from '../PopupManagerStore';
 import { AccountStore, AccountLoginData } from '../AccountStore';
 import { AuthorizePopupState } from '../AuthorizePopupStore';
-import { OpenLoginStore, LoginParams } from '../OpenLoginStore';
+import { OpenLoginStore, LoginParams, InitParams } from '../OpenLoginStore';
 import { AppContextStore } from '../AppContextStore';
 
 export class AuthenticationStore {
@@ -24,9 +24,9 @@ export class AuthenticationStore {
     );
   }
 
-  async rehydrate() {
-    if (this.openLoginStore.sessionId) {
-      await this.openLoginStore.init();
+  async rehydrate({ sessionId }: InitParams = {}) {
+    if (this.openLoginStore.sessionId || sessionId) {
+      await this.openLoginStore.init({ sessionId });
     }
 
     await this.syncAccount();

--- a/src/stores/EmbededWalletStore/EmbeddedWalletStore.ts
+++ b/src/stores/EmbededWalletStore/EmbeddedWalletStore.ts
@@ -109,8 +109,8 @@ export class EmbeddedWalletStore implements Wallet {
         return this.authenticationStore.logout();
       },
 
-      onRehydrate: () => {
-        return this.authenticationStore.rehydrate();
+      onRehydrate: ({ sessionId }) => {
+        return this.authenticationStore.rehydrate({ sessionId });
       },
 
       onUserInfoRequest: async () => {

--- a/src/stores/OpenLoginStore/OpenLoginStore.ts
+++ b/src/stores/OpenLoginStore/OpenLoginStore.ts
@@ -11,6 +11,10 @@ export type LoginParams = {
   redirectUrl?: string;
 };
 
+export type InitParams = {
+  sessionId?: string;
+};
+
 type OpenLoginStoreOptions = Pick<OpenLoginOptions, 'storageKey'> & {
   sessionNamespace?: string;
 };
@@ -137,9 +141,13 @@ export class OpenLoginStore {
     });
   }
 
-  async init() {
+  async init({ sessionId }: InitParams = {}) {
     if (this.initialized) {
       return; // Do nothing if already initialized
+    }
+
+    if (sessionId) {
+      this.openLogin.state.store.set('sessionId', sessionId);
     }
 
     await this.openLogin.init();


### PR DESCRIPTION
The problem is that in Safari localStorage of IFRAMEs are isolated/sandboxed. So we have to pass some information using redirectUrl params (`sessionId` is enough) to be able to restore the auth session in the Wallet IFRAME.