### PR TITLE
Disable Biconomy for CERE ERC20 transfer

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -9,8 +9,8 @@ REACT_APP_DDC_API=https://ddc.freeport.dev.cere.network
 # UI
 REACT_APP_HELP_URL=https://cere.network/cere-wallet-faq/
 
-# Biconomy
-REACT_APP_BICONOMY_API_KEY=WijpEd4xz.589021f1-32b9-438e-bc34-e289bd81b016
+# Biconomy (disabled)
+# REACT_APP_BICONOMY_API_KEY=WijpEd4xz.589021f1-32b9-438e-bc34-e289bd81b016
 
 # Wallet
 REACT_APP_DEFAULT_RPC=https://polygon-mumbai.infura.io/v3/248b37a1123943a9b5c975eb2c93a2ab

--- a/.env.prod
+++ b/.env.prod
@@ -7,8 +7,8 @@ REACT_APP_WALLET_API=https://api.wallet.cere.io
 # UI
 REACT_APP_HELP_URL=https://cere.network/cere-wallet-faq/
 
-# Biconomy
-REACT_APP_BICONOMY_API_KEY=LErteiIAp.4a97451e-0d3d-4f07-b414-ad095f7f53db
+# Biconomy (disabled)
+# REACT_APP_BICONOMY_API_KEY=LErteiIAp.4a97451e-0d3d-4f07-b414-ad095f7f53db
 
 # Wallet
 REACT_APP_DEFAULT_RPC=https://polygon-mainnet.infura.io/v3/bc9098ea001147ec98ab91925e0a2487

--- a/.env.stage
+++ b/.env.stage
@@ -7,8 +7,8 @@ REACT_APP_WALLET_API=https://api.wallet.stg.cere.io
 # UI
 REACT_APP_HELP_URL=https://cere.network/cere-wallet-faq/
 
-# Biconomy
-REACT_APP_BICONOMY_API_KEY=siF_udFZl.27b0b4a2-db97-455e-85d3-c7f000352c1d
+# Biconomy (disabled)
+# REACT_APP_BICONOMY_API_KEY=siF_udFZl.27b0b4a2-db97-455e-85d3-c7f000352c1d
 
 # Wallet
 REACT_APP_DEFAULT_RPC=https://polygon-mumbai.infura.io/v3/fb100652794946c6b94185d09ab0bb57

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
--
+- Disable Biconomy for CERE ERC20 transfer
 
 ### v1.21.0
 


### PR DESCRIPTION
Disable Biconome for the transfer since CERE ERC20 token SCs do not currently support  Biconomy forwarding