### PR TITLE
Fix `Sign Out` from the wallet widget error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
--
+- Fix `Sign Out` from the wallet widget error
 
 ### v1.22.0
 

--- a/src/stores/AuthenticationStore/AuthenticationStore.ts
+++ b/src/stores/AuthenticationStore/AuthenticationStore.ts
@@ -143,6 +143,8 @@ export class AuthenticationStore {
   private async syncAccountWithState(state: AuthorizePopupState) {
     if (state.result) {
       this.openLoginStore.syncWithEncodedState(state.result, state.sessionId);
+
+      await this.openLoginStore.init();
     }
 
     const account = await this.syncAccount();


### PR DESCRIPTION
Initialize Open Login during login flow, otherwice log out is incomplete  which leads to undefined behaviour like the `Sign Out` error 