### PR TITLE
Fix incorrect sentry reporting in case user entered wrong OTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
-- [[Feature](https://www.notion.so/cere/Switch-DEV-frontends-to-new-infra-563be1f2c5ee4b92aa87808f3480fe22?pvs=4)] Configure auto-tests to work in VPN protected environment
+- [[Fix](https://www.notion.so/cere/Wrong-OTP-code-entry-error-logged-incorrectly-2139b9953e354db4829953a6161b68ba?pvs=4)] Fix incorrect sentry reporting in case user entered wrong OTP
 
 ### v1.26.0
 

--- a/src/api/auth-api.service.ts
+++ b/src/api/auth-api.service.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosResponse } from 'axios';
 
 import { reportError } from '~/reporting';
 import { WALLET_API } from '~/constants';
@@ -31,9 +31,14 @@ export class AuthApiService {
         email,
         code,
       });
-    } catch (err) {
-      reportError(err);
+    } catch (error) {
+      const isUserError = error instanceof AxiosError && error.code === 'ERR_BAD_REQUEST';
+
+      if (!isUserError) {
+        reportError(error);
+      }
     }
+
     return result?.data.code === 'SUCCESS' ? result?.data.data.token : null;
   }
 


### PR DESCRIPTION
Do not send sentry report if the HTTP status is `400` for OTP verification requests