### PR TITLE
fix: Fractional Matic balance transfer issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
--
+- Fixed fractional Matic balance transfer issue
 
 ### v1.29.0
 

--- a/src/components/Transfer/useTransferForm.ts
+++ b/src/components/Transfer/useTransferForm.ts
@@ -4,7 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { isValidAddress } from '@cere-wallet/wallet-engine';
 
 import { Asset } from '~/stores';
-import { BigNumber } from 'ethers';
+import { utils } from 'ethers';
 import { useEffect } from 'react';
 
 export type UseTransferFormOptions = {
@@ -35,8 +35,8 @@ const validationSchema = yup.object({
         return true;
       }
 
-      const amount = BigNumber.from(value);
-      const balance = BigNumber.from(selectedAsset.balance);
+      const balance = utils.parseUnits(String(selectedAsset.balance || 0), selectedAsset.decimals);
+      const amount = utils.parseUnits(value, selectedAsset.decimals);
 
       return balance.gte(amount)
         ? true


### PR DESCRIPTION
When the available or transferred Matic balance is a fractional number - the wallet gives a console error, making it impossible to transfer the asset. Fixed it by properly converting fractional values to `BigNumber`