### PR TITLE
fix: Matic transfer UI showing error event after successful transfer transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
-- 
+- Fixed Matic transfer UI showing error event after successful transaction on Mainnet
 
 ### v1.29.1
 

--- a/src/stores/ApprovalStore/TransactionHandler.ts
+++ b/src/stores/ApprovalStore/TransactionHandler.ts
@@ -2,6 +2,7 @@ import { BigNumber } from 'ethers';
 import { runInAction, when } from 'mobx';
 import { ContractName, SendTransactionRequest, getTokenConfig, parseTransactionData } from '@cere-wallet/wallet-engine';
 
+import { reportError } from '~/reporting';
 import { Wallet } from '../types';
 import { convertPrice } from './convertPrice';
 import { PopupManagerStore } from '../PopupManagerStore';
@@ -121,11 +122,11 @@ export class TransactionHandler {
       });
 
       const pendingTx = await this.wallet.provider!.getTransaction(transactionId!);
-      const txReceipt = await pendingTx.wait();
-
-      isRejected = !txReceipt.status;
-    } catch {
+      await pendingTx.wait();
+    } catch (error) {
       isRejected = true;
+
+      reportError(error);
     }
 
     runInAction(() => {


### PR DESCRIPTION
The issue is reproducible on the wallet prod (polygon mainnet) only. So I added a fix which should fix the issue, but not for sure. Also added error logging for this case.