### PR TITLE
fix: Change the wallet client production domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3332,9 +3332,9 @@
       }
     },
     "node_modules/@cere/torus-embed": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.2.6.tgz",
-      "integrity": "sha512-nL0WJgzkLlYwSLsA2SajhPW8NaGGOdXS3VY3UzjETFB4H0gxtnsK508FDH+Oxc3ll0JJOJix0SID/XZR5Hx3ZA==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@cere/torus-embed/-/torus-embed-0.2.7.tgz",
+      "integrity": "sha512-j+MApO5FhG49x6TVgNg/CTOU0uSs2c/ZaWNWnW3ZOinC9F/yt01e1vle7U26k66oeljnWWS0CfEWTNb3Gckv5A==",
       "dependencies": {
         "@metamask/obs-store": "^7.0.0",
         "@toruslabs/http-helpers": "^3.2.0",
@@ -39134,7 +39134,7 @@
       "version": "0.13.0",
       "license": "ISC",
       "dependencies": {
-        "@cere/torus-embed": "0.2.6",
+        "@cere/torus-embed": "0.2.7",
         "@types/bn.js": "^5.1.1",
         "@types/readable-stream": "^2.3.15",
         "bn.js": "^5.2.1"

--- a/packages/embed-wallet-inject/package.json
+++ b/packages/embed-wallet-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere/embed-wallet-inject",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "sideEffects": false,
   "type": "module",
   "types": "./dist/types/index.d.ts",

--- a/packages/embed-wallet/CHANGELOG.md
+++ b/packages/embed-wallet/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Release Notes:
 
-### vNext
+### v0.14.0
 
-- 
+- Switch Cere Wallet Client to new domain
 
 ### v0.13.0
 

--- a/packages/embed-wallet/package.json
+++ b/packages/embed-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere/embed-wallet",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Cere Wallet SDK to integrate the wallet into a web application.",
   "sideEffects": false,
   "main": "dist/bundle.umd.js",
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/cere-io/cere-wallet-client/tree/master/packages/embed-wallet",
   "license": "ISC",
   "dependencies": {
-    "@cere/torus-embed": "0.2.6",
+    "@cere/torus-embed": "0.2.7",
     "@types/bn.js": "^5.1.1",
     "@types/readable-stream": "^2.3.15",
     "bn.js": "^5.2.1"

--- a/packages/embed-wallet/src/EmbedWallet.ts
+++ b/packages/embed-wallet/src/EmbedWallet.ts
@@ -34,7 +34,12 @@ const buildEnvMap: Record<WalletEnvironment, TORUS_BUILD_ENV_TYPE> = {
   local: 'development',
   dev: 'cere-dev',
   stage: 'cere-stage',
-  prod: 'cere',
+  /**
+   * TODO: Change back to 'cere' when the MetaMask block issue is resolved
+   *
+   * @see https://github.com/MetaMask/eth-phishing-detect/issues/19072
+   */
+  prod: 'cere-aws',
 };
 
 const createBalance = (


### PR DESCRIPTION
Switch the production Cere Wallet client domain to
```
wallet.core.aws.cere.io
```
It will resolve the MetaMask block issue.