### PR TITLE
feat: Add embed-wallet-inject permissions option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39615,7 +39615,7 @@
     },
     "packages/embed-wallet": {
       "name": "@cere/embed-wallet",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "license": "ISC",
       "dependencies": {
         "@cere/torus-embed": "0.2.7",
@@ -39626,7 +39626,7 @@
     },
     "packages/embed-wallet-inject": {
       "name": "@cere/embed-wallet-inject",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "dependencies": {
         "@polkadot/extension-inject": "^0.46.6"
       },

--- a/packages/embed-wallet-inject/package.json
+++ b/packages/embed-wallet-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere/embed-wallet-inject",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "sideEffects": false,
   "type": "module",
   "types": "./dist/types/index.d.ts",

--- a/packages/embed-wallet-inject/src/index.ts
+++ b/packages/embed-wallet-inject/src/index.ts
@@ -1,4 +1,5 @@
-import { EmbedWallet } from '@cere/embed-wallet';
+import { EmbedWallet, PermissionRequest } from '@cere/embed-wallet';
+
 import { PolkadotInjector } from './polkadot';
 
 type InjectTarget = 'polkadot';
@@ -7,6 +8,7 @@ export type InjectOptions = {
   name?: string;
   targets?: InjectTarget[];
   autoConnect?: boolean;
+  permissions?: PermissionRequest;
 };
 
 /**

--- a/packages/embed-wallet/package.json
+++ b/packages/embed-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cere/embed-wallet",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Cere Wallet SDK to integrate the wallet into a web application.",
   "sideEffects": false,
   "main": "dist/bundle.umd.js",


### PR DESCRIPTION
Allow passing permissions to `embed-wallet-inject` util