### PR TITLE
fix(authorization) Wait 60 seconds before first otp resend request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
-- Fix wait 60 seconds before first otp resend request
+-
 
 ### v1.32.0
 


### PR DESCRIPTION
 - 60 seconds otp delay after email input

![Screenshot from 2024-03-05 07-27-41](https://github.com/cere-io/cere-wallet-client/assets/90830691/820c42d2-3e47-4257-ac99-74e6035ad08d)
![Screenshot from 2024-03-05 07-27-51](https://github.com/cere-io/cere-wallet-client/assets/90830691/a1ca820d-9c1c-4864-a99c-58be88670ac3)
![Screenshot from 2024-03-05 07-35-09](https://github.com/cere-io/cere-wallet-client/assets/90830691/7ae297f4-f702-4f73-8dc9-04eba3be4153)
