### PR TITLE
feat: Allow exporting wallet to JSON backup file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### vNext
 
-- 
+- Add support of wallet export as a JSON backup file
 
 ### v1.36.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36681,8 +36681,8 @@
     },
     "packages/embed-wallet": {
       "name": "@cere/embed-wallet",
-      "version": "0.17.0",
-      "license": "ISC",
+      "version": "0.17.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cere/torus-embed": "0.2.8",
         "@types/bn.js": "^5.1.1",
@@ -36692,7 +36692,8 @@
     },
     "packages/embed-wallet-inject": {
       "name": "@cere/embed-wallet-inject",
-      "version": "0.17.0",
+      "version": "0.17.1",
+      "license": "Apache-2.0",
       "dependencies": {
         "@polkadot/extension-inject": "^0.46.6"
       },

--- a/packages/ui/src/icons/index.ts
+++ b/packages/ui/src/icons/index.ts
@@ -29,6 +29,7 @@ export {
   ArrowDropDown as ArrowDropDownIcon,
   ArrowDropUp as ArrowDropUpIcon,
   ArrowBackIos as ArrowBackIosIcon,
+  Download as DownloadIcon,
 } from '@mui/icons-material';
 
 export type { IconProps } from '@mui/material';

--- a/packages/wallet-engine/src/accounts.ts
+++ b/packages/wallet-engine/src/accounts.ts
@@ -2,6 +2,7 @@ import Wallet from 'ethereumjs-wallet';
 import { getED25519Key } from '@toruslabs/openlogin-ed25519';
 import { decodeAddress, encodeAddress, isEthereumAddress } from '@polkadot/util-crypto';
 import { hexToU8a, isHex } from '@polkadot/util';
+import { Keyring } from '@polkadot/keyring';
 
 import { KeyPair, KeyType, Account } from './types';
 import { CERE_SS58_PREFIX } from './constants';
@@ -41,6 +42,13 @@ export type AccountOptions = KeyPairOptions & {
 
 export const getKeyPair = ({ privateKey, type }: KeyPairOptions): KeyPair => {
   return pairFactoryMap[type](privateKey);
+};
+
+export const exportAccountToJson = ({ privateKey, type, passphrase }: KeyPairOptions & { passphrase?: string }) => {
+  const { publicKey, secretKey } = getKeyPair({ type, privateKey });
+  const keyring = new Keyring({ type });
+
+  return keyring.addFromPair({ publicKey, secretKey }).toJson(passphrase);
 };
 
 export const getAccount = ({ privateKey, type, name }: AccountOptions): Account => ({

--- a/src/routes/Settings/Settings.tsx
+++ b/src/routes/Settings/Settings.tsx
@@ -24,7 +24,7 @@ const SectionHeader = styled(CardHeader)({
 
 const SectionButton = styled(Button)({
   minWidth: 250,
-  flexShrink: 0,
+  height: 44,
 }) as typeof Button;
 
 export const Settings = () => {
@@ -60,7 +60,7 @@ export const Settings = () => {
             <Stack direction={isMobile ? 'column' : 'row'} spacing={3}>
               <Typography flex={1} variant="body2" color="text.secondary">
                 Click the button bellow to manage your Authentication & Security settings and you will be redirecting to
-                the OpenLogin settings
+                the OpenLogin settings.
               </Typography>
 
               {accountLink && (
@@ -84,7 +84,8 @@ export const Settings = () => {
           <CardContent>
             <Stack direction={isMobile ? 'column' : 'row'} spacing={3}>
               <Typography flex={1} variant="body2" color="text.secondary">
-                Export your wallet account to a JSON file
+                JSON backup file lets you restore your account or use it with Cere Tools, even if a direct connection to
+                Cere Wallet isn't available. Please keep it confidential and don't share it with third parties.
               </Typography>
 
               <SectionButton

--- a/src/routes/Settings/Settings.tsx
+++ b/src/routes/Settings/Settings.tsx
@@ -1,13 +1,14 @@
 import {
-  Box,
   Button,
   Card,
   CardContent,
-  Grid,
+  CardHeader,
   IconButton,
   SecurityIcon,
+  DownloadIcon,
   Stack,
   Typography,
+  styled,
   useIsMobile,
 } from '@cere-wallet/ui';
 import { useEffect, useState } from 'react';
@@ -15,56 +16,90 @@ import { useEffect, useState } from 'react';
 import { PageHeader } from '~/components';
 import { useAccountStore, useAuthenticationStore, useOpenLoginStore } from '~/hooks';
 
+const SectionHeader = styled(CardHeader)({
+  borderBottom: 'none',
+  backgroundColor: 'transparent',
+  paddingBottom: 0,
+});
+
+const SectionButton = styled(Button)({
+  minWidth: 250,
+  flexShrink: 0,
+}) as typeof Button;
+
 export const Settings = () => {
   const isMobile = useIsMobile();
-  const { user } = useAccountStore();
-  const { accountUrl } = useOpenLoginStore();
+  const accountStore = useAccountStore();
   const authenticationStore = useAuthenticationStore();
+  const { accountUrl } = useOpenLoginStore();
   const [accountLink, setAccountLink] = useState<string>();
+  const walletDownloadUrl = accountStore.exportAccount('ed25519');
+  const cereAddress = accountStore.getAccount('ed25519')?.address;
 
   useEffect(() => {
     authenticationStore
-      .getRedirectUrl({ callbackUrl: accountUrl, forceMfa: true, emailHint: user?.email, skipIntro: true })
+      .getRedirectUrl({ callbackUrl: accountUrl, forceMfa: true, emailHint: accountStore.user?.email, skipIntro: true })
       .then(setAccountLink);
-  }, [authenticationStore, accountUrl, user]);
+  }, [authenticationStore, accountUrl, accountStore.user]);
 
   return (
     <>
       <PageHeader title="Settings" />
 
-      <Box maxWidth="md">
+      <Stack maxWidth="md" spacing={2}>
         <Card>
+          <SectionHeader
+            title="Authentication & Security"
+            avatar={
+              <IconButton variant="filled" size="medium">
+                <SecurityIcon />
+              </IconButton>
+            }
+          />
           <CardContent>
-            <Grid spacing={1} direction="row" alignItems="center" container>
-              <Grid item>
-                <Box maxWidth="sm">
-                  <Stack direction="row" gap={2} alignItems="center">
-                    <IconButton variant="filled" size="medium">
-                      <SecurityIcon />
-                    </IconButton>
-                    <Typography variant="body1" fontWeight="semibold">
-                      Authentication & Security
-                    </Typography>
-                  </Stack>
-                  <Box marginTop="16px">
-                    <Typography variant="body2" color="text.secondary">
-                      Click the button bellow to manage your Authentication & Security settings and you will be
-                      redirecting to the OpenLogin settings
-                    </Typography>
-                  </Box>
-                </Box>
-              </Grid>
-              <Grid flexGrow={1} marginTop={isMobile ? 3 : 0} item>
-                {accountLink && (
-                  <Button target="_blank" fullWidth href={accountLink} variant="outlined">
-                    Go to OpenLogin settings
-                  </Button>
-                )}
-              </Grid>
-            </Grid>
+            <Stack direction={isMobile ? 'column' : 'row'} spacing={3}>
+              <Typography flex={1} variant="body2" color="text.secondary">
+                Click the button bellow to manage your Authentication & Security settings and you will be redirecting to
+                the OpenLogin settings
+              </Typography>
+
+              {accountLink && (
+                <SectionButton target="_blank" fullWidth={isMobile} href={accountLink} variant="outlined">
+                  Go to OpenLogin settings
+                </SectionButton>
+              )}
+            </Stack>
           </CardContent>
         </Card>
-      </Box>
+
+        <Card>
+          <SectionHeader
+            title="Account export"
+            avatar={
+              <IconButton variant="filled" size="medium">
+                <DownloadIcon />
+              </IconButton>
+            }
+          />
+          <CardContent>
+            <Stack direction={isMobile ? 'column' : 'row'} spacing={3}>
+              <Typography flex={1} variant="body2" color="text.secondary">
+                Export your wallet account to a JSON file
+              </Typography>
+
+              <SectionButton
+                disabled={!cereAddress}
+                download={`${cereAddress}.json`}
+                fullWidth={isMobile}
+                href={walletDownloadUrl}
+                variant="outlined"
+              >
+                Download
+              </SectionButton>
+            </Stack>
+          </CardContent>
+        </Card>
+      </Stack>
     </>
   );
 };

--- a/src/stores/AccountStore/AccountStore.ts
+++ b/src/stores/AccountStore/AccountStore.ts
@@ -1,6 +1,6 @@
 import { makeAutoObservable, when } from 'mobx';
 import { UserInfo } from '@cere-wallet/communication';
-import { Account, KeyPair } from '@cere-wallet/wallet-engine';
+import { Account, KeyPair, KeyType, exportAccountToJson } from '@cere-wallet/wallet-engine';
 
 import { User, Wallet } from '../types';
 import { createSharedState } from '../sharedState';
@@ -62,6 +62,23 @@ export class AccountStore {
       type,
       name: this.user?.name || `Account #${index}`,
     }));
+  }
+
+  exportAccount(type: KeyType) {
+    if (!this.privateKey) {
+      throw new Error('No private key found!');
+    }
+
+    const keyData = exportAccountToJson({ privateKey: this.privateKey, type });
+    const accountBlob = new Blob([JSON.stringify(keyData)], {
+      type: 'application/json',
+    });
+
+    return URL.createObjectURL(accountBlob);
+  }
+
+  getAccount(type: KeyType) {
+    return this.accounts.find((account) => account.type === type);
   }
 
   /**

--- a/src/stores/AccountStore/AccountStore.ts
+++ b/src/stores/AccountStore/AccountStore.ts
@@ -64,12 +64,15 @@ export class AccountStore {
     }));
   }
 
-  exportAccount(type: KeyType) {
+  exportAccount(type: KeyType, passphrase?: string) {
     if (!this.privateKey) {
       throw new Error('No private key found!');
     }
 
-    const keyData = exportAccountToJson({ privateKey: this.privateKey, type });
+    /**
+     * TODO: Implement passphrase UI to not hardcode it here to be empty string ('')
+     */
+    const keyData = exportAccountToJson({ privateKey: this.privateKey, type, passphrase: passphrase || '' });
     const accountBlob = new Blob([JSON.stringify(keyData)], {
       type: 'application/json',
     });


### PR DESCRIPTION
Added new section to Cere Wallet Settings screen which allows to download the wallet account as JSON backup file. Currently supports only `ed25519` (Cere Network) wallet. Later we can improve it with support of EVM wallet export and passphrase.

![image](https://github.com/cere-io/cere-wallet-client/assets/56070785/50f100ea-97d6-45ae-90c8-09718b2438a3)
