### PR TITLE
feature: Let users enter an encryption password during account export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNext
 
 - Added multi-chain signature API to the wallet client and SDK
+- Let users enter an encryption password during account export
 
 ### v1.37.0
 

--- a/packages/ui/src/theme/index.ts
+++ b/packages/ui/src/theme/index.ts
@@ -203,6 +203,22 @@ export const createTheme = ({ whiteLabel, isGame }: any = {}): Theme => {
         },
 
         styleOverrides: {
+          root: ({ theme, ownerState: props }) => {
+            const color = props.color === 'inherit' ? undefined : theme.palette[props.color || 'primary'];
+            const disabledColor = color && alpha(color.main, theme.palette.action.disabledOpacity);
+            const textColor = color && color.contrastText;
+
+            return (
+              color && {
+                '&.Mui-disabled': {
+                  borderColor: disabledColor,
+                  backgroundColor: props.variant === 'contained' ? disabledColor : undefined,
+                  color: props.variant === 'contained' ? textColor : color?.main,
+                },
+              }
+            );
+          },
+
           contained: {
             backgroundColor: isGame && '#F32758',
             borderRadius: isGame ? 4 : 30,

--- a/src/stores/AccountStore/AccountStore.ts
+++ b/src/stores/AccountStore/AccountStore.ts
@@ -63,9 +63,6 @@ export class AccountStore {
       throw new Error('No private key found!');
     }
 
-    /**
-     * TODO: Implement passphrase UI to not hardcode it here to be empty string ('')
-     */
     const keyData = exportAccountToJson({ privateKey: this.privateKey, type, passphrase: passphrase || '' });
     const accountBlob = new Blob([JSON.stringify(keyData)], {
       type: 'application/json',


### PR DESCRIPTION
Allow users to enter JSON backup encryption password during the account export

![image](https://github.com/cere-io/cere-wallet-client/assets/56070785/c3dba290-74e5-4544-bc0d-645182a82edc)
